### PR TITLE
APIドキュメント: OpenAPI 自動生成とUI追加

### DIFF
--- a/apps/web/public/swagger/index.html
+++ b/apps/web/public/swagger/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>RichmanManage API Docs</title>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css" />
+    <style>
+      html, body { height: 100%; margin: 0; }
+      #swagger-ui { height: 100vh; }
+    </style>
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
+    <script>
+      window.onload = () => {
+        window.ui = SwaggerUIBundle({
+          url: '/api-docs',
+          dom_id: '#swagger-ui',
+          presets: [SwaggerUIBundle.presets.apis],
+          layout: 'BaseLayout',
+        });
+      };
+    </script>
+  </body>
+  </html>
+

--- a/apps/web/src/app/api-docs/route.ts
+++ b/apps/web/src/app/api-docs/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { getApiDocs } from '@/lib/swagger';
+
+export async function GET() {
+  const spec = await getApiDocs();
+  return NextResponse.json(spec);
+}

--- a/apps/web/src/app/api/loans/route.ts
+++ b/apps/web/src/app/api/loans/route.ts
@@ -86,6 +86,26 @@ const handleApiError = (error: unknown, context: string) => {
 };
 
 // GET /api/loans - 借入一覧取得
+/**
+ * @swagger
+ * /api/loans:
+ *   get:
+ *     tags: [Loans]
+ *     summary: 借入一覧を取得
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema: { type: integer }
+ *       - in: query
+ *         name: limit
+ *         schema: { type: integer }
+ *       - in: query
+ *         name: property_id
+ *         schema: { type: string, format: uuid }
+ *     responses:
+ *       200:
+ *         description: 成功
+ */
 export async function GET(request: NextRequest) {
   return withPerformanceMonitoring(async () => {
     try {

--- a/apps/web/src/app/api/properties/route.ts
+++ b/apps/web/src/app/api/properties/route.ts
@@ -90,6 +90,26 @@ const handleApiError = (error: unknown, context: string) => {
 };
 
 // GET /api/properties - 物件一覧取得
+/**
+ * @swagger
+ * /api/properties:
+ *   get:
+ *     tags: [Properties]
+ *     summary: 物件一覧を取得
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema: { type: integer }
+ *       - in: query
+ *         name: limit
+ *         schema: { type: integer }
+ *       - in: query
+ *         name: search
+ *         schema: { type: string }
+ *     responses:
+ *       200:
+ *         description: 成功
+ */
 export async function GET(request: NextRequest) {
   return withPerformanceMonitoring(async () => {
     try {

--- a/apps/web/src/app/docs/api/page.tsx
+++ b/apps/web/src/app/docs/api/page.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import React from 'react';
+
+export default function ApiDocsPage() {
+  return (
+    <div style={{ height: '100vh' }}>
+      <iframe
+        src="/swagger/index.html"
+        title="API Docs"
+        style={{ width: '100%', height: '100%', border: 'none' }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/lib/swagger.ts
+++ b/apps/web/src/lib/swagger.ts
@@ -1,0 +1,28 @@
+import { createSwaggerSpec } from 'next-swagger-doc';
+
+export async function getApiDocs() {
+  const spec = createSwaggerSpec({
+    apiFolder: 'src/app/api',
+    definition: {
+      openapi: '3.0.0',
+      info: {
+        title: 'RichmanManage API',
+        version: '1.0.0',
+        description: '不動産投資管理システムのAPI仕様',
+      },
+      servers: [
+        {
+          url: process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000',
+          description: 'Local dev',
+        },
+      ],
+      components: {
+        securitySchemes: {
+          bearerAuth: { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
+        },
+      },
+      security: [{ bearerAuth: [] }],
+    },
+  });
+  return spec;
+}


### PR DESCRIPTION
目的\n- フロント/バックの契約を可視化し二重管理を回避するため、OpenAPI自動生成とUIを導入しました。\n\n変更点\n- : next-swagger-doc によるJSON仕様の提供\n- : Swagger UI(CDN)をiframeで埋め込み表示（Reactのpeer依存を避けるための実装）\n- properties/loans のGETに最小限のSwagger注釈追加（段階的に拡充予定）\n\n補足\n- UIはCDN読込の静的HTMLを  に配置し、/docs/api から参照\n- React 19とのpeer依存衝突を回避するため、依存追加は行っていません\n\n今後\n- 残りのAPI（expenses/rent-rolls/users等）への注釈追加\n- スキーマの詳細化（エラー/ページネーションmetaなど）\n- docsの整合性（古い手順の是正）を別PRで対応します。