### PR TITLE
feat: DTO↔DBマッピング集約とZod整合（PR-1）

### DIFF
--- a/apps/web/src/lib/api/schemas/expense.ts
+++ b/apps/web/src/lib/api/schemas/expense.ts
@@ -20,11 +20,11 @@ export const CreateExpenseSchema = z.object({
   expense_date: z.string().datetime('有効な日付を指定してください'),
   category: ExpenseCategorySchema,
   amount: z.number().min(0, '金額は0円以上で入力してください'),
-  vendor: z.string().min(1, '支払先を入力してください').optional(),
-  description: z.string().optional(),
-  receipt_url: z.string().url('有効なURLを指定してください').optional(),
+  vendor: z.string().min(1, '支払先を入力してください').nullable().optional(),
+  description: z.string().nullable().optional(),
+  receipt_url: z.string().url('有効なURLを指定してください').nullable().optional(),
   is_recurring: z.boolean().default(false),
-  recurring_frequency: z.enum(['monthly', 'quarterly', 'annually']).optional(),
+  recurring_frequency: z.enum(['monthly', 'quarterly', 'annually']).nullable().optional(),
 });
 
 /**

--- a/apps/web/src/lib/api/schemas/rent-roll.ts
+++ b/apps/web/src/lib/api/schemas/rent-roll.ts
@@ -13,7 +13,7 @@ export const CreateRentRollSchema = z.object({
   property_id: z.string().uuid('有効な物件IDを指定してください'),
   room_number: z.string().min(1, '部屋番号を入力してください'),
   tenant_name: z.string().nullable().optional(),
-  monthly_rent: z.number().min(0, '家賃は0円以上で入力してください'),
+  monthly_rent: z.number().min(0, '家賃は0円以上で入力してください').nullable().optional(),
   occupancy_status: OccupancyStatusSchema,
   lease_start_date: z.string().datetime().nullable().optional(),
   lease_end_date: z.string().datetime().nullable().optional(),

--- a/apps/web/src/lib/mappers/expenses.ts
+++ b/apps/web/src/lib/mappers/expenses.ts
@@ -1,0 +1,106 @@
+import type { CreateExpense, UpdateExpense } from '@/lib/api/schemas/expense';
+
+// recurring_frequency('monthly'|'quarterly'|'annually') ⇄ recurring_interval_months(1|3|12)
+const freqToInterval: Record<string, number> = {
+  monthly: 1,
+  quarterly: 3,
+  annually: 12,
+};
+
+const intervalToFreq: Record<number, string> = {
+  1: 'monthly',
+  3: 'quarterly',
+  12: 'annually',
+};
+
+type DbExpenseInsert = {
+  property_id: string;
+  expense_date: string;
+  category: string;
+  amount: number;
+  vendor?: string | null; // 旧スキーマ互換
+  vendor_name?: string | null; // 新スキーマ互換
+  description?: string | null;
+  receipt_url?: string | null; // 旧スキーマ互換
+  receipt_file_url?: string | null; // 新スキーマ互換
+  is_recurring: boolean;
+  recurring_frequency?: string | null; // 旧スキーマ互換
+  recurring_interval_months?: number | null; // 新スキーマ互換
+};
+
+type DbExpenseUpdate = Partial<DbExpenseInsert> & { updated_at?: string };
+
+export function mapExpenseDtoToDbForCreate(input: CreateExpense): DbExpenseInsert {
+  const interval = input.recurring_frequency
+    ? (freqToInterval[input.recurring_frequency] ?? null)
+    : null;
+
+  return {
+    property_id: input.property_id,
+    expense_date: input.expense_date,
+    category: input.category,
+    amount: input.amount,
+    vendor: input.vendor ?? null,
+    vendor_name: input.vendor ?? null,
+    description: input.description ?? null,
+    receipt_url: input.receipt_url ?? null,
+    receipt_file_url: input.receipt_url ?? null,
+    is_recurring: input.is_recurring ?? false,
+    recurring_frequency: input.recurring_frequency ?? null,
+    recurring_interval_months: interval,
+  };
+}
+
+export function mapExpenseDtoToDbForUpdate(input: UpdateExpense): DbExpenseUpdate {
+  const out: DbExpenseUpdate = {};
+  if (input.property_id !== undefined) out.property_id = input.property_id;
+  if (input.expense_date !== undefined) out.expense_date = input.expense_date;
+  if (input.category !== undefined) out.category = input.category;
+  if (input.amount !== undefined) out.amount = input.amount;
+  if (input.vendor !== undefined) {
+    out.vendor = input.vendor ?? null;
+    out.vendor_name = input.vendor ?? null;
+  }
+  if (input.description !== undefined) out.description = input.description ?? null;
+  if (input.receipt_url !== undefined) {
+    out.receipt_url = input.receipt_url ?? null;
+    out.receipt_file_url = input.receipt_url ?? null;
+  }
+  if (input.is_recurring !== undefined) out.is_recurring = input.is_recurring;
+  if (input.recurring_frequency !== undefined) {
+    out.recurring_frequency = input.recurring_frequency ?? null;
+    out.recurring_interval_months = input.recurring_frequency
+      ? (freqToInterval[input.recurring_frequency] ?? null)
+      : null;
+  }
+  out.updated_at = new Date().toISOString();
+  return out;
+}
+
+type DbExpenseRowForMap = {
+  vendor?: string | null;
+  vendor_name?: string | null;
+  receipt_url?: string | null;
+  receipt_file_url?: string | null;
+  recurring_frequency?: string | null;
+  recurring_interval_months?: number | null;
+} & Record<string, unknown>;
+
+export function mapExpenseDbToDto(
+  input: DbExpenseRowForMap
+): Record<string, unknown> & { vendor: string | null; receipt_url: string | null } {
+  const vendor = input.vendor ?? input.vendor_name ?? null;
+  const receipt = input.receipt_url ?? input.receipt_file_url ?? null;
+  const freq =
+    input.recurring_frequency ??
+    (typeof input.recurring_interval_months === 'number'
+      ? intervalToFreq[input.recurring_interval_months]
+      : undefined) ??
+    null;
+  return {
+    ...input,
+    vendor,
+    receipt_url: receipt,
+    recurring_frequency: freq,
+  };
+}

--- a/apps/web/src/lib/mappers/index.ts
+++ b/apps/web/src/lib/mappers/index.ts
@@ -1,0 +1,3 @@
+export * as loanMappers from './loans';
+export * as rentRollMappers from './rentRolls';
+export * as expenseMappers from './expenses';

--- a/apps/web/src/lib/mappers/loans.ts
+++ b/apps/web/src/lib/mappers/loans.ts
@@ -1,0 +1,92 @@
+import type { CreateLoanInput, UpdateLoanInput, LoanType } from '@/lib/api/schemas/loan';
+
+// DBのloan_typeとUIのloan_typeの差異を吸収
+// UI: 'mortgage' | 'business' | 'personal' | 'other'
+// DB(例): 'property_acquisition' | 'business' | 'personal' | 'other'
+const uiToDbLoanType: Record<LoanType | 'mortgage', string> = {
+  mortgage: 'property_acquisition',
+  business: 'business',
+  personal: 'personal',
+  other: 'other',
+};
+
+const dbToUiLoanType: Record<string, LoanType> = {
+  property_acquisition: 'mortgage',
+  business: 'business',
+  personal: 'personal',
+  other: 'other',
+};
+
+type DbLoanInsert = {
+  property_id: string;
+  lender_name: string;
+  loan_type: string;
+  principal_amount: number;
+  current_balance: number;
+  // DBの列差異を吸収: interest_rate もしくは initial_interest_rate/current_interest_rate
+  interest_rate?: number;
+  initial_interest_rate?: number;
+  current_interest_rate?: number;
+  loan_term_months: number;
+  monthly_payment: number;
+};
+
+type DbLoanUpdate = Partial<Omit<DbLoanInsert, 'property_id' | 'principal_amount'>> & {
+  updated_at?: string;
+};
+
+// 可能なら initial/current 両方を埋めるが、未知列を送るとエラーになるため、
+// 呼び出し側で最終的に存在カラムのみを選択して利用する想定。
+export function mapLoanDtoToDbForCreate(input: CreateLoanInput): DbLoanInsert {
+  const mapped: DbLoanInsert = {
+    property_id: input.property_id,
+    lender_name: input.lender_name,
+    loan_type: uiToDbLoanType[input.loan_type] ?? 'other',
+    principal_amount: input.principal_amount,
+    current_balance: input.current_balance,
+    interest_rate: input.interest_rate, // 既存スキーマ互換
+    initial_interest_rate: input.interest_rate, // 新スキーマ互換（存在時）
+    current_interest_rate: input.interest_rate, // 新スキーマ互換（存在時）
+    loan_term_months: input.loan_term_months,
+    monthly_payment: input.monthly_payment,
+  };
+  return mapped;
+}
+
+export function mapLoanDtoToDbForUpdate(input: Partial<UpdateLoanInput>): DbLoanUpdate {
+  const out: DbLoanUpdate = {};
+  if (input.lender_name !== undefined) out.lender_name = input.lender_name;
+  if (input.loan_type !== undefined) out.loan_type = uiToDbLoanType[input.loan_type] ?? 'other';
+  if (input.current_balance !== undefined) out.current_balance = input.current_balance;
+  if (input.interest_rate !== undefined) {
+    out.interest_rate = input.interest_rate; // 既存スキーマ互換
+    out.initial_interest_rate = input.interest_rate; // 新スキーマ互換
+    out.current_interest_rate = input.interest_rate; // 新スキーマ互換
+  }
+  if (input.monthly_payment !== undefined) out.monthly_payment = input.monthly_payment;
+  out.updated_at = new Date().toISOString();
+  return out;
+}
+
+type DbLoanRowForMap = {
+  loan_type?: string;
+  interest_rate?: number | null;
+  current_interest_rate?: number | null;
+  initial_interest_rate?: number | null;
+} & Record<string, unknown>;
+
+export function mapLoanDbToDto(
+  input: DbLoanRowForMap
+): Record<string, unknown> & { loan_type: LoanType; interest_rate: number } {
+  const uiType = input.loan_type ? (dbToUiLoanType[input.loan_type] ?? 'other') : 'other';
+  const rate =
+    (typeof input.interest_rate === 'number' ? input.interest_rate : undefined) ??
+    (typeof input.current_interest_rate === 'number' ? input.current_interest_rate : undefined) ??
+    (typeof input.initial_interest_rate === 'number' ? input.initial_interest_rate : undefined) ??
+    0;
+  return {
+    ...input,
+    loan_type: uiType,
+    interest_rate: rate,
+  };
+}

--- a/apps/web/src/lib/mappers/rentRolls.ts
+++ b/apps/web/src/lib/mappers/rentRolls.ts
@@ -1,0 +1,105 @@
+import type { CreateRentRoll, UpdateRentRoll, OccupancyStatus } from '@/lib/api/schemas/rent-roll';
+
+// UI: occupancy_status ⇄ DB: room_status
+const uiToDbStatus: Record<OccupancyStatus | 'occupied' | 'vacant' | 'reserved', string> = {
+  occupied: 'occupied',
+  vacant: 'vacant',
+  reserved: 'reserved',
+};
+
+const dbToUiStatus: Record<string, OccupancyStatus> = {
+  occupied: 'occupied',
+  vacant: 'vacant',
+  reserved: 'reserved',
+};
+
+type DbRentRollInsert = {
+  property_id: string;
+  room_number: string;
+  tenant_name: string | null;
+  monthly_rent: number | null;
+  room_status: string; // DB名
+  lease_start_date: string | null;
+  lease_end_date: string | null;
+  deposit_months: number | null;
+  key_money_months: number | null;
+  notes: string | null;
+};
+
+type DbRentRollUpdate = Partial<DbRentRollInsert> & { updated_at?: string };
+
+function toMonthsFromAmount(
+  amount: number | null | undefined,
+  baseMonthly: number | null | undefined
+) {
+  if (amount == null || baseMonthly == null || baseMonthly <= 0) return null;
+  // 金額→月数（小数第2位で四捨五入）
+  const months = amount / baseMonthly;
+  return Math.round(months * 100) / 100;
+}
+
+function toAmountFromMonths(
+  months: number | null | undefined,
+  baseMonthly: number | null | undefined
+) {
+  if (months == null || baseMonthly == null || baseMonthly <= 0) return null;
+  // 月数→金額（小数第0〜2位に抑制、ここでは小数第0.01円で四捨五入）
+  const amount = months * baseMonthly;
+  return Math.round(amount * 100) / 100;
+}
+
+export function mapRentRollDtoToDbForCreate(input: CreateRentRoll): DbRentRollInsert {
+  return {
+    property_id: input.property_id,
+    room_number: input.room_number,
+    tenant_name: input.tenant_name ?? null,
+    monthly_rent: input.monthly_rent ?? null,
+    room_status: uiToDbStatus[input.occupancy_status] ?? 'vacant',
+    lease_start_date: input.lease_start_date ?? null,
+    lease_end_date: input.lease_end_date ?? null,
+    deposit_months: toMonthsFromAmount(input.security_deposit, input.monthly_rent),
+    key_money_months: toMonthsFromAmount(input.key_money, input.monthly_rent),
+    notes: input.notes ?? null,
+  };
+}
+
+export function mapRentRollDtoToDbForUpdate(input: Partial<UpdateRentRoll>): DbRentRollUpdate {
+  const out: DbRentRollUpdate = {};
+  if (input.room_number !== undefined) out.room_number = input.room_number;
+  if (input.tenant_name !== undefined) out.tenant_name = input.tenant_name ?? null;
+  if (input.monthly_rent !== undefined) out.monthly_rent = input.monthly_rent ?? null;
+  if (input.occupancy_status !== undefined)
+    out.room_status = uiToDbStatus[input.occupancy_status] ?? 'vacant';
+  if (input.lease_start_date !== undefined) out.lease_start_date = input.lease_start_date ?? null;
+  if (input.lease_end_date !== undefined) out.lease_end_date = input.lease_end_date ?? null;
+  if (input.security_deposit !== undefined)
+    out.deposit_months = toMonthsFromAmount(input.security_deposit, input.monthly_rent);
+  if (input.key_money !== undefined)
+    out.key_money_months = toMonthsFromAmount(input.key_money, input.monthly_rent);
+  if (input.notes !== undefined) out.notes = input.notes ?? null;
+  out.updated_at = new Date().toISOString();
+  return out;
+}
+
+type DbRentRollRowForMap = {
+  room_status?: string;
+  deposit_months?: number | null;
+  key_money_months?: number | null;
+  monthly_rent?: number | null;
+} & Record<string, unknown>;
+
+export function mapRentRollDbToDto(input: DbRentRollRowForMap): Record<string, unknown> & {
+  occupancy_status: OccupancyStatus;
+  security_deposit: number | null;
+  key_money: number | null;
+} {
+  const status = input.room_status ? (dbToUiStatus[input.room_status] ?? 'vacant') : 'vacant';
+  const sd = toAmountFromMonths(input.deposit_months ?? null, input.monthly_rent ?? null);
+  const km = toAmountFromMonths(input.key_money_months ?? null, input.monthly_rent ?? null);
+  return {
+    ...input,
+    occupancy_status: status,
+    security_deposit: sd,
+    key_money: km,
+  };
+}


### PR DESCRIPTION
目的: スキーマ整合の軽量適用。DTO↔DB変換の単一化と422回避の下地作り\n\n変更:\n- mappers追加: loans/rentRolls/expenses + export集約\n- Zod整合: expenses, rent-rolls のnullable/optional精査\n- POST/PUTにDTO→DBアダプタ適用（loans/expenses/rent-rolls）\n- 既存DB互換の安全キーのみ送信（新スキーマカラムは段階適用）\n\n影響: APIの作成/更新フロー（GETは未変更）\n\n次PR: GET側DB→DTO適用、loansフォーム/CRUD、共通エラーUI