### PR TITLE
feat: GET側DB→DTOマッピング適用（PR-2）

### DIFF
--- a/apps/web/src/app/api/expenses/route.ts
+++ b/apps/web/src/app/api/expenses/route.ts
@@ -6,6 +6,7 @@ import {
   ExpenseQuerySchema,
   ExpenseResponseSchema,
 } from '@/lib/api/schemas/expense';
+import { mapExpenseDbToDto } from '@/lib/mappers/expenses';
 import { mapExpenseDtoToDbForCreate } from '@/lib/mappers/expenses';
 import { z } from 'zod';
 import { getCache } from '@/lib/cache/redis-cache';
@@ -204,12 +205,13 @@ export async function GET(request: NextRequest) {
         throw error;
       }
 
-      // レスポンス形式に変換（property情報を除外）
+      // レスポンス形式に変換（property情報を除外）+ DB→DTO正規化
       const expenses =
         data?.map((expense) => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const { property, ...expenseData } = expense;
-          return ExpenseResponseSchema.parse(expenseData);
+          const { property, ...expenseData } = expense as Record<string, unknown>;
+          const normalized = mapExpenseDbToDto(expenseData);
+          return ExpenseResponseSchema.parse(normalized);
         }) || [];
 
       // ページネーションメタデータを計算

--- a/apps/web/src/app/api/loans/[id]/route.ts
+++ b/apps/web/src/app/api/loans/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
 import { ApiResponse } from '@/lib/api/response';
 import { UpdateLoanSchema, LoanResponseSchema } from '@/lib/api/schemas/loan';
+import { mapLoanDbToDto } from '@/lib/mappers/loans';
 import { mapLoanDtoToDbForUpdate } from '@/lib/mappers/loans';
 import { z } from 'zod';
 
@@ -115,10 +116,11 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
         return ApiResponse.notFound('借入が見つかりません');
       }
 
-      // レスポンス形式に変換（property情報を除外）
+      // レスポンス形式に変換（property情報を除外）+ DB→DTO正規化
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { property, ...loanData } = loan;
-      const loanResponse = LoanResponseSchema.parse(loanData);
+      const { property, ...loanData } = loan as Record<string, unknown>;
+      const normalized = mapLoanDbToDto(loanData);
+      const loanResponse = LoanResponseSchema.parse(normalized);
 
       return ApiResponse.success(loanResponse);
     } catch (error) {

--- a/apps/web/src/app/api/loans/route.ts
+++ b/apps/web/src/app/api/loans/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
 import { ApiResponse } from '@/lib/api/response';
 import { CreateLoanSchema, LoanQuerySchema, LoanResponseSchema } from '@/lib/api/schemas/loan';
+import { mapLoanDbToDto } from '@/lib/mappers/loans';
 import { mapLoanDtoToDbForCreate } from '@/lib/mappers/loans';
 import { z } from 'zod';
 import { getCache } from '@/lib/cache/redis-cache';
@@ -173,12 +174,13 @@ export async function GET(request: NextRequest) {
         throw error;
       }
 
-      // レスポンス形式に変換（property情報を除外）
+      // レスポンス形式に変換（property情報を除外）+ DB→DTO正規化
       const loans =
         data?.map((loan) => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const { property, ...loanData } = loan;
-          return LoanResponseSchema.parse(loanData);
+          const { property, ...loanData } = loan as Record<string, unknown>;
+          const normalized = mapLoanDbToDto(loanData);
+          return LoanResponseSchema.parse(normalized);
         }) || [];
 
       // ページネーションメタデータを計算

--- a/apps/web/src/app/api/rent-rolls/[id]/route.ts
+++ b/apps/web/src/app/api/rent-rolls/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
 import { ApiResponse } from '@/lib/api/response';
 import { UpdateRentRollSchema, RentRollResponseSchema } from '@/lib/api/schemas/rent-roll';
+import { mapRentRollDbToDto } from '@/lib/mappers/rentRolls';
 import { mapRentRollDtoToDbForUpdate } from '@/lib/mappers/rentRolls';
 import { z } from 'zod';
 
@@ -130,10 +131,11 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
         return ApiResponse.notFound('レントロールが見つかりません');
       }
 
-      // レスポンス形式に変換（property情報を除外）
+      // レスポンス形式に変換（property情報を除外）+ DB→DTO正規化
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { property, ...rentRollData } = rentRoll;
-      const rentRollResponse = RentRollResponseSchema.parse(rentRollData);
+      const { property, ...rentRollData } = rentRoll as Record<string, unknown>;
+      const normalized = mapRentRollDbToDto(rentRollData);
+      const rentRollResponse = RentRollResponseSchema.parse(normalized);
 
       return ApiResponse.success(rentRollResponse);
     } catch (error) {

--- a/apps/web/src/app/api/rent-rolls/route.ts
+++ b/apps/web/src/app/api/rent-rolls/route.ts
@@ -6,6 +6,7 @@ import {
   RentRollQuerySchema,
   RentRollResponseSchema,
 } from '@/lib/api/schemas/rent-roll';
+import { mapRentRollDbToDto } from '@/lib/mappers/rentRolls';
 import { mapRentRollDtoToDbForCreate } from '@/lib/mappers/rentRolls';
 import { z } from 'zod';
 import { getCache } from '@/lib/cache/redis-cache';
@@ -186,12 +187,13 @@ export async function GET(request: NextRequest) {
         throw error;
       }
 
-      // レスポンス形式に変換（property情報を除外）
+      // レスポンス形式に変換（property情報を除外）+ DB→DTO正規化
       const rentRolls =
         data?.map((rentRoll) => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const { property, ...rentRollData } = rentRoll;
-          return RentRollResponseSchema.parse(rentRollData);
+          const { property, ...rentRollData } = rentRoll as Record<string, unknown>;
+          const normalized = mapRentRollDbToDto(rentRollData);
+          return RentRollResponseSchema.parse(normalized);
         }) || [];
 
       // ページネーションメタデータを計算


### PR DESCRIPTION
目的: GETレスポンスでDB差分（enum/列名）を吸収し、UI DTOへ正規化。\n\n変更:\n- loans GET（一覧/詳細）: mapLoanDbToDto適用→LoanResponseSchemaで整形\n- rent-rolls GET（一覧/詳細）: mapRentRollDbToDto適用→RentRollResponseSchemaで整形\n- expenses GET: mapExpenseDbToDto適用→ExpenseResponseSchemaで整形\n\n非対象:\n- クエリの列名は据え置き（スキーマ移行後に切替）。\n\n影響: APIのGETレスポンス整合性（UI DTOに統一）