### PR TITLE
PR5: Problem Details導入（エラー統一の段階移行）

### DIFF
--- a/apps/web/src/lib/api/openapi/document.test.ts
+++ b/apps/web/src/lib/api/openapi/document.test.ts
@@ -38,6 +38,12 @@ describe('OpenAPI (Zod-first)', () => {
     expect(spec.components?.responses).toHaveProperty('ValidationError');
     expect(spec.components?.parameters).toHaveProperty('PageParam');
     expect(spec.components?.parameters).toHaveProperty('LimitParam');
+    // responses use problem+json for 4xx/5xx
+    const responses = spec.components?.responses as
+      | Record<string, { content?: Record<string, unknown> }>
+      | undefined;
+    const una = responses?.['Unauthorized'];
+    expect(una?.content).toHaveProperty('application/problem+json');
 
     // loans detail endpoints
     const loanDetail = (spec.paths as Record<string, unknown>)['/api/loans/{id}'] as

--- a/apps/web/src/lib/api/openapi/document.ts
+++ b/apps/web/src/lib/api/openapi/document.ts
@@ -1,7 +1,12 @@
 import { createDocument } from 'zod-openapi';
 import { ownersPaths } from './paths/owners.paths';
 import { loansPaths } from './paths/loans.paths';
-import { ApiErrorSchema, ErrorResponseSchema, ApiMetaSchema } from '../schemas/common';
+import {
+  ApiErrorSchema,
+  ErrorResponseSchema,
+  ApiMetaSchema,
+  ProblemDetailsSchema,
+} from '../schemas/common';
 import { OwnerResponseSchema } from '../schemas/owner';
 import { LoanResponseSchema } from '../schemas/loan';
 import { PropertyResponseSchema } from '../schemas/property';
@@ -77,25 +82,30 @@ export function generateOpenAPIDoc() {
       responses: {
         Unauthorized: {
           description: '認証エラー',
-          content: { 'application/json': { schema: ErrorResponseSchema } },
+          content: { 'application/problem+json': { schema: ProblemDetailsSchema } },
         },
         ValidationError: {
           description: 'バリデーションエラー',
-          content: { 'application/json': { schema: ErrorResponseSchema } },
+          content: { 'application/problem+json': { schema: ProblemDetailsSchema } },
         },
         NotFound: {
           description: '対象が見つかりません',
-          content: { 'application/json': { schema: ErrorResponseSchema } },
+          content: { 'application/problem+json': { schema: ProblemDetailsSchema } },
         },
         BadRequest: {
           description: '不正なリクエスト',
-          content: { 'application/json': { schema: ErrorResponseSchema } },
+          content: { 'application/problem+json': { schema: ProblemDetailsSchema } },
+        },
+        InternalError: {
+          description: 'サーバ内部エラー',
+          content: { 'application/problem+json': { schema: ProblemDetailsSchema } },
         },
       },
       schemas: {
         ApiError: ApiErrorSchema,
         ErrorResponse: ErrorResponseSchema,
         ApiMeta: ApiMetaSchema,
+        ProblemDetails: ProblemDetailsSchema,
         Owner: OwnerResponseSchema,
         Loan: LoanResponseSchema,
         Property: PropertyResponseSchema,

--- a/apps/web/src/lib/api/schemas/common.ts
+++ b/apps/web/src/lib/api/schemas/common.ts
@@ -18,3 +18,14 @@ export const ErrorResponseSchema = z.object({
   data: z.null(),
   error: ApiErrorSchema,
 });
+
+// RFC 9457 Problem Details
+export const ProblemDetailsSchema = z.object({
+  type: z.string().url().optional(),
+  title: z.string(),
+  status: z.number().int(),
+  detail: z.string().optional(),
+  instance: z.string().optional(),
+  // extension members for gradual migration / compatibility
+  code: z.string().optional(),
+});

--- a/packages/generated/openapi.json
+++ b/packages/generated/openapi.json
@@ -2025,6 +2025,34 @@
           }
         }
       },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer"
+          },
+          "detail": {
+            "type": "string"
+          },
+          "instance": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "status"
+        ]
+      },
       "Owner": {
         "type": "object",
         "properties": {
@@ -2505,9 +2533,9 @@
       "Unauthorized": {
         "description": "認証エラー",
         "content": {
-          "application/json": {
+          "application/problem+json": {
             "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+              "$ref": "#/components/schemas/ProblemDetails"
             }
           }
         }
@@ -2515,9 +2543,9 @@
       "ValidationError": {
         "description": "バリデーションエラー",
         "content": {
-          "application/json": {
+          "application/problem+json": {
             "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+              "$ref": "#/components/schemas/ProblemDetails"
             }
           }
         }
@@ -2525,9 +2553,9 @@
       "NotFound": {
         "description": "対象が見つかりません",
         "content": {
-          "application/json": {
+          "application/problem+json": {
             "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+              "$ref": "#/components/schemas/ProblemDetails"
             }
           }
         }
@@ -2535,9 +2563,19 @@
       "BadRequest": {
         "description": "不正なリクエスト",
         "content": {
-          "application/json": {
+          "application/problem+json": {
             "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+              "$ref": "#/components/schemas/ProblemDetails"
+            }
+          }
+        }
+      },
+      "InternalError": {
+        "description": "サーバ内部エラー",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails"
             }
           }
         }

--- a/packages/generated/prev.json
+++ b/packages/generated/prev.json
@@ -1,1 +1,2547 @@
-{"currentRoute":"get - /api/openapi","error":"Serverless-offline: route not found.","existingRoutes":["get - /jtb-dev/bills","get - /jtb-dev/bills/{masterCustomerId}","post - /jtb-dev/cardcompanyfiles","get - /jtb-dev/cardcompanyfiles","get - /jtb-dev/cardcompanyfiles/download","get - /jtb-dev/cardcompanyfiles/existence","post - /jtb-dev/changeDeals","get - /jtb-dev/changeDeals/info/{id}","put - /jtb-dev/changeDeals/workflow/{id}","get - /jtb-dev/changeDeals/{id}","put - /jtb-dev/changeDeals/{id}","put - /jtb-dev/changeDeals/{id}/cancel","get - /jtb-dev/contractorDetails/{id}","post - /jtb-dev/contractors","get - /jtb-dev/contractors","put - /jtb-dev/contractors/{contractorId}","post - /jtb-dev/customerTermiDeals","get - /jtb-dev/customerTermiDeals/info/{id}","put - /jtb-dev/customerTermiDeals/workflow/{id}","get - /jtb-dev/customerTermiDeals/{id}","put - /jtb-dev/customerTermiDeals/{id}","put - /jtb-dev/customerTermiDeals/{id}/cancel","put - /jtb-dev/customerUserAccounts/{contractorId}","get - /jtb-dev/customers","get - /jtb-dev/customers/{id}","delete - /jtb-dev/customerusers","post - /jtb-dev/customerusers","get - /jtb-dev/customerusers","put - /jtb-dev/customerusers/{id}","get - /jtb-dev/dashboards","delete - /jtb-dev/dealerusers","post - /jtb-dev/dealerusers","get - /jtb-dev/dealerusers","put - /jtb-dev/dealerusers/phonenumber","put - /jtb-dev/dealerusers/{id}","put - /jtb-dev/deals/{id}/comment","put - /jtb-dev/deals/{id}/customerCode","get - /jtb-dev/deals/{id}/customerList","get - /jtb-dev/dealsForCustomer","get - /jtb-dev/dealsForJTB","get - /jtb-dev/documents","get - /jtb-dev/documents/{documentType}","get - /jtb-dev/downloadFile/{id}","put - /jtb-dev/email","get - /jtb-dev/file/bills","get - /jtb-dev/files/{id}","get - /jtb-dev/formMasterJson/{ver}","get - /jtb-dev/information","post - /jtb-dev/messages","get - /jtb-dev/metabase","post - /jtb-dev/newDeals","get - /jtb-dev/newDeals/{id}","put - /jtb-dev/newDeals/{id}","put - /jtb-dev/newDeals/{id}/cancel","get - /jtb-dev/presetFormJson/{presetType}/{ver}","get - /jtb-dev/proxy/houjinBango/{ver}/num","get - /jtb-dev/proxy/postcodes/{postcode}","post - /jtb-dev/storeDealPdf","post - /jtb-dev/terminalTermiDeals","get - /jtb-dev/terminalTermiDeals/info/{id}","put - /jtb-dev/terminalTermiDeals/workflow/{id}","get - /jtb-dev/terminalTermiDeals/{id}","put - /jtb-dev/terminalTermiDeals/{id}","put - /jtb-dev/terminalTermiDeals/{id}/cancel","get - /jtb-dev/terminals","get - /jtb-dev/terminals/file","get - /jtb-dev/terminals/{id}","get - /jtb-dev/terms","get - /jtb-dev/terms/{termsNumber}","post - /jtb-dev/uploadfile","put - /jtb-dev/userAccounts/lastLoginDate","get - /jtb-dev/userAccounts/{userName}","put - /jtb-dev/userName"],"statusCode":404}
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "RichmanManage API",
+    "version": "1.0.0",
+    "description": "不動産投資管理システムのAPI仕様（Zod由来）",
+    "contact": {
+      "name": "RichmanManage Team",
+      "url": "https://github.com/denof-inc/richman-manage",
+      "email": "support@example.com"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://opensource.org/licenses/MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3000",
+      "description": "Local"
+    }
+  ],
+  "security": [
+    {
+      "BearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Owners",
+      "description": "所有者管理API"
+    },
+    {
+      "name": "Loans",
+      "description": "借入管理API"
+    },
+    {
+      "name": "Properties",
+      "description": "物件管理API"
+    },
+    {
+      "name": "Expenses",
+      "description": "支出管理API"
+    },
+    {
+      "name": "RentRolls",
+      "description": "レントロール管理API"
+    },
+    {
+      "name": "Users",
+      "description": "ユーザー管理API"
+    }
+  ],
+  "paths": {
+    "/api/owners": {
+      "get": {
+        "tags": [
+          "Owners"
+        ],
+        "operationId": "listOwners",
+        "summary": "所有者一覧を取得",
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Owner"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Owners"
+        ],
+        "operationId": "createOwner",
+        "summary": "所有者を作成",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 100
+                  },
+                  "owner_kind": {
+                    "type": "string",
+                    "enum": [
+                      "individual",
+                      "corporation"
+                    ],
+                    "default": "individual"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "作成成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Owner"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError"
+          }
+        }
+      }
+    },
+    "/api/loans": {
+      "get": {
+        "tags": [
+          "Loans"
+        ],
+        "operationId": "listLoans",
+        "summary": "借入一覧を取得",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageParam"
+          },
+          {
+            "$ref": "#/components/parameters/LimitParam"
+          },
+          {
+            "in": "query",
+            "name": "property_id",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Loan"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Loans"
+        ],
+        "operationId": "createLoan",
+        "summary": "借入を作成",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "property_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "owner_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "lender_name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 100
+                  },
+                  "branch_name": {
+                    "type": "string",
+                    "maxLength": 100
+                  },
+                  "loan_type": {
+                    "type": "string",
+                    "enum": [
+                      "mortgage",
+                      "business",
+                      "personal",
+                      "other"
+                    ]
+                  },
+                  "principal_amount": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                  },
+                  "current_balance": {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "interest_rate": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 100
+                  },
+                  "loan_term_months": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0
+                  },
+                  "monthly_payment": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                  },
+                  "notes": {
+                    "type": "string",
+                    "maxLength": 2000
+                  }
+                },
+                "required": [
+                  "lender_name",
+                  "loan_type",
+                  "principal_amount",
+                  "current_balance",
+                  "interest_rate",
+                  "loan_term_months",
+                  "monthly_payment"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "作成成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Loan"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError"
+          }
+        }
+      }
+    },
+    "/api/loans/{id}": {
+      "get": {
+        "tags": [
+          "Loans"
+        ],
+        "operationId": "getLoan",
+        "summary": "借入詳細を取得",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Loan"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Loans"
+        ],
+        "operationId": "updateLoan",
+        "summary": "借入を更新",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "lender_name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 100
+                  },
+                  "branch_name": {
+                    "type": "string",
+                    "maxLength": 100
+                  },
+                  "loan_type": {
+                    "type": "string",
+                    "enum": [
+                      "mortgage",
+                      "business",
+                      "personal",
+                      "other"
+                    ]
+                  },
+                  "owner_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "current_balance": {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "interest_rate": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 100
+                  },
+                  "monthly_payment": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                  },
+                  "notes": {
+                    "type": "string",
+                    "maxLength": 2000
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Loan"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Loans"
+        ],
+        "operationId": "deleteLoan",
+        "summary": "借入を削除（論理削除）",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "削除完了",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/properties": {
+      "get": {
+        "tags": [
+          "Properties"
+        ],
+        "operationId": "listProperties",
+        "summary": "物件一覧を取得",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageParam"
+          },
+          {
+            "$ref": "#/components/parameters/LimitParam"
+          },
+          {
+            "$ref": "#/components/parameters/SearchParam"
+          },
+          {
+            "in": "query",
+            "name": "property_type",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "apartment",
+                "office",
+                "house",
+                "land",
+                "commercial",
+                "industrial",
+                "mixed_use",
+                "other"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Property"
+                  }
+                },
+                "examples": {
+                  "sample": {
+                    "value": [
+                      {
+                        "id": "550e8400-e29b-41d4-a716-446655440000",
+                        "user_id": "550e8400-e29b-41d4-a716-446655440001",
+                        "name": "青山マンション",
+                        "address": "東京都港区南青山1-1-1",
+                        "property_type": "apartment",
+                        "purchase_price": 50000000,
+                        "purchase_date": "2023-04-01",
+                        "current_valuation": 52000000,
+                        "created_at": "2024-01-01T00:00:00Z",
+                        "updated_at": "2024-01-10T00:00:00Z",
+                        "deleted_at": null
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Properties"
+        ],
+        "operationId": "createProperty",
+        "summary": "物件を作成",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 100
+                  },
+                  "address": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200
+                  },
+                  "property_type": {
+                    "type": "string",
+                    "enum": [
+                      "apartment",
+                      "office",
+                      "house",
+                      "land",
+                      "commercial",
+                      "industrial",
+                      "mixed_use",
+                      "other"
+                    ]
+                  },
+                  "purchase_price": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                  },
+                  "purchase_date": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                  },
+                  "current_valuation": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                  }
+                },
+                "required": [
+                  "name",
+                  "address",
+                  "property_type",
+                  "purchase_price",
+                  "purchase_date"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "作成成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Property"
+                },
+                "examples": {
+                  "created": {
+                    "value": {
+                      "id": "550e8400-e29b-41d4-a716-446655440002",
+                      "user_id": "550e8400-e29b-41d4-a716-446655440001",
+                      "name": "青山マンション",
+                      "address": "東京都港区南青山1-1-1",
+                      "property_type": "apartment",
+                      "purchase_price": 50000000,
+                      "purchase_date": "2023-04-01",
+                      "current_valuation": 52000000,
+                      "created_at": "2024-01-01T00:00:00Z",
+                      "updated_at": "2024-01-01T00:00:00Z",
+                      "deleted_at": null
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError"
+          }
+        }
+      }
+    },
+    "/api/properties/{id}": {
+      "get": {
+        "tags": [
+          "Properties"
+        ],
+        "operationId": "getProperty",
+        "summary": "物件詳細を取得",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Property"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Properties"
+        ],
+        "operationId": "updateProperty",
+        "summary": "物件を更新",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 100
+                  },
+                  "address": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200
+                  },
+                  "property_type": {
+                    "type": "string",
+                    "enum": [
+                      "apartment",
+                      "office",
+                      "house",
+                      "land",
+                      "commercial",
+                      "industrial",
+                      "mixed_use",
+                      "other"
+                    ]
+                  },
+                  "purchase_price": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                  },
+                  "purchase_date": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                  },
+                  "current_valuation": {
+                    "type": [
+                      "number",
+                      "null"
+                    ],
+                    "exclusiveMinimum": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Property"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Properties"
+        ],
+        "operationId": "deleteProperty",
+        "summary": "物件を削除（論理削除）",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "削除完了",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/expenses": {
+      "get": {
+        "tags": [
+          "Expenses"
+        ],
+        "operationId": "listExpenses",
+        "summary": "支出一覧を取得",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageParam"
+          },
+          {
+            "$ref": "#/components/parameters/LimitParam"
+          },
+          {
+            "$ref": "#/components/parameters/SearchParam"
+          },
+          {
+            "in": "query",
+            "name": "property_id",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "query",
+            "name": "category",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "start_date",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "in": "query",
+            "name": "end_date",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Expense"
+                  }
+                },
+                "examples": {
+                  "sample": {
+                    "value": [
+                      {
+                        "id": "550e8400-e29b-41d4-a716-446655441100",
+                        "property_id": "550e8400-e29b-41d4-a716-446655440000",
+                        "expense_date": "2024-05-01T00:00:00Z",
+                        "category": "management_fee",
+                        "amount": 12000,
+                        "vendor": "管理会社A",
+                        "description": "管理費",
+                        "receipt_url": null,
+                        "is_recurring": true,
+                        "recurring_frequency": "monthly",
+                        "created_at": "2024-05-01T00:00:00Z",
+                        "updated_at": "2024-05-01T00:00:00Z",
+                        "deleted_at": null
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Expenses"
+        ],
+        "operationId": "createExpense",
+        "summary": "支出を作成",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "property_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "expense_date": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "category": {
+                    "type": "string",
+                    "enum": [
+                      "management_fee",
+                      "repair_cost",
+                      "utility",
+                      "insurance",
+                      "tax",
+                      "other"
+                    ]
+                  },
+                  "amount": {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "vendor": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "minLength": 1
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "receipt_url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "format": "uri"
+                  },
+                  "is_recurring": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "recurring_frequency": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "monthly",
+                      "quarterly",
+                      "annually"
+                    ]
+                  }
+                },
+                "required": [
+                  "property_id",
+                  "expense_date",
+                  "category",
+                  "amount"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "作成成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Expense"
+                },
+                "examples": {
+                  "created": {
+                    "value": {
+                      "id": "550e8400-e29b-41d4-a716-446655441101",
+                      "property_id": "550e8400-e29b-41d4-a716-446655440000",
+                      "expense_date": "2024-05-01T00:00:00Z",
+                      "category": "management_fee",
+                      "amount": 12000,
+                      "vendor": "管理会社A",
+                      "description": "管理費",
+                      "receipt_url": null,
+                      "is_recurring": true,
+                      "recurring_frequency": "monthly",
+                      "created_at": "2024-05-01T00:00:00Z",
+                      "updated_at": "2024-05-01T00:00:00Z",
+                      "deleted_at": null
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError"
+          }
+        }
+      }
+    },
+    "/api/expenses/{id}": {
+      "get": {
+        "tags": [
+          "Expenses"
+        ],
+        "operationId": "getExpense",
+        "summary": "支出詳細を取得",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Expense"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Expenses"
+        ],
+        "operationId": "updateExpense",
+        "summary": "支出を更新",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "property_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "expense_date": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "category": {
+                    "type": "string",
+                    "enum": [
+                      "management_fee",
+                      "repair_cost",
+                      "utility",
+                      "insurance",
+                      "tax",
+                      "other"
+                    ]
+                  },
+                  "amount": {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "vendor": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "minLength": 1
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "receipt_url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "format": "uri"
+                  },
+                  "is_recurring": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "recurring_frequency": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "monthly",
+                      "quarterly",
+                      "annually"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Expense"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Expenses"
+        ],
+        "operationId": "deleteExpense",
+        "summary": "支出を削除（論理削除）",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "削除完了",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/rent-rolls": {
+      "get": {
+        "tags": [
+          "RentRolls"
+        ],
+        "operationId": "listRentRolls",
+        "summary": "レントロール一覧を取得",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageParam"
+          },
+          {
+            "$ref": "#/components/parameters/LimitParam"
+          },
+          {
+            "$ref": "#/components/parameters/SearchParam"
+          },
+          {
+            "in": "query",
+            "name": "property_id",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RentRoll"
+                  }
+                },
+                "examples": {
+                  "sample": {
+                    "value": [
+                      {
+                        "id": "550e8400-e29b-41d4-a716-446655442200",
+                        "property_id": "550e8400-e29b-41d4-a716-446655440000",
+                        "room_number": "101",
+                        "tenant_name": "山田太郎",
+                        "monthly_rent": 85000,
+                        "occupancy_status": "occupied",
+                        "lease_start_date": "2024-01-01T00:00:00Z",
+                        "lease_end_date": null,
+                        "security_deposit": 85000,
+                        "key_money": 0,
+                        "notes": null,
+                        "created_at": "2024-01-01T00:00:00Z",
+                        "updated_at": "2024-05-01T00:00:00Z",
+                        "deleted_at": null
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "RentRolls"
+        ],
+        "operationId": "createRentRoll",
+        "summary": "レントロールを作成",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "property_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "room_number": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "tenant_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "monthly_rent": {
+                    "type": [
+                      "number",
+                      "null"
+                    ],
+                    "minimum": 0
+                  },
+                  "occupancy_status": {
+                    "type": "string",
+                    "enum": [
+                      "occupied",
+                      "vacant",
+                      "reserved"
+                    ]
+                  },
+                  "lease_start_date": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "format": "date-time"
+                  },
+                  "lease_end_date": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "format": "date-time"
+                  },
+                  "security_deposit": {
+                    "type": [
+                      "number",
+                      "null"
+                    ],
+                    "minimum": 0
+                  },
+                  "key_money": {
+                    "type": [
+                      "number",
+                      "null"
+                    ],
+                    "minimum": 0
+                  },
+                  "notes": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "property_id",
+                  "room_number",
+                  "occupancy_status"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "作成成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RentRoll"
+                },
+                "examples": {
+                  "created": {
+                    "value": {
+                      "id": "550e8400-e29b-41d4-a716-446655442201",
+                      "property_id": "550e8400-e29b-41d4-a716-446655440000",
+                      "room_number": "101",
+                      "tenant_name": "山田太郎",
+                      "monthly_rent": 85000,
+                      "occupancy_status": "occupied",
+                      "lease_start_date": "2024-01-01T00:00:00Z",
+                      "lease_end_date": null,
+                      "security_deposit": 85000,
+                      "key_money": 0,
+                      "notes": null,
+                      "created_at": "2024-01-01T00:00:00Z",
+                      "updated_at": "2024-05-01T00:00:00Z",
+                      "deleted_at": null
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError"
+          }
+        }
+      }
+    },
+    "/api/rent-rolls/{id}": {
+      "get": {
+        "tags": [
+          "RentRolls"
+        ],
+        "operationId": "getRentRoll",
+        "summary": "レントロール詳細を取得",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RentRoll"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "RentRolls"
+        ],
+        "operationId": "updateRentRoll",
+        "summary": "レントロールを更新",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "room_number": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "tenant_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "monthly_rent": {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "occupancy_status": {
+                    "type": "string",
+                    "enum": [
+                      "occupied",
+                      "vacant",
+                      "reserved"
+                    ]
+                  },
+                  "lease_start_date": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "format": "date-time"
+                  },
+                  "lease_end_date": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "format": "date-time"
+                  },
+                  "security_deposit": {
+                    "type": [
+                      "number",
+                      "null"
+                    ],
+                    "minimum": 0
+                  },
+                  "key_money": {
+                    "type": [
+                      "number",
+                      "null"
+                    ],
+                    "minimum": 0
+                  },
+                  "notes": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RentRoll"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "RentRolls"
+        ],
+        "operationId": "deleteRentRoll",
+        "summary": "レントロールを削除（論理削除）",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "削除完了",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/users": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "operationId": "listUsers",
+        "summary": "ユーザー一覧を取得",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageParam"
+          },
+          {
+            "$ref": "#/components/parameters/LimitParam"
+          },
+          {
+            "$ref": "#/components/parameters/SearchParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/User"
+                  }
+                },
+                "examples": {
+                  "sample": {
+                    "value": [
+                      {
+                        "id": "550e8400-e29b-41d4-a716-446655443300",
+                        "email": "user@example.com",
+                        "name": "一般ユーザー",
+                        "role": "viewer",
+                        "timezone": "Asia/Tokyo",
+                        "language": "ja",
+                        "created_at": "2024-01-01T00:00:00Z",
+                        "updated_at": "2024-05-01T00:00:00Z"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "operationId": "createUser",
+        "summary": "ユーザーを作成",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 100
+                  },
+                  "role": {
+                    "type": "string",
+                    "enum": [
+                      "admin",
+                      "owner",
+                      "manager",
+                      "viewer",
+                      "auditor"
+                    ],
+                    "default": "viewer"
+                  },
+                  "password": {
+                    "allOf": [
+                      {
+                        "type": "string",
+                        "pattern": "[A-Z]",
+                        "minLength": 8
+                      },
+                      {
+                        "type": "string",
+                        "pattern": "[a-z]"
+                      },
+                      {
+                        "type": "string",
+                        "pattern": "[0-9]"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "email",
+                  "name",
+                  "password"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "作成成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                },
+                "examples": {
+                  "created": {
+                    "value": {
+                      "id": "550e8400-e29b-41d4-a716-446655443301",
+                      "email": "newuser@example.com",
+                      "name": "新規ユーザー",
+                      "role": "viewer",
+                      "timezone": "Asia/Tokyo",
+                      "language": "ja",
+                      "created_at": "2024-06-01T00:00:00Z",
+                      "updated_at": "2024-06-01T00:00:00Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError"
+          }
+        }
+      }
+    },
+    "/api/users/{id}": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "operationId": "getUser",
+        "summary": "ユーザー詳細を取得",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Users"
+        ],
+        "operationId": "updateUser",
+        "summary": "ユーザーを更新",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 100
+                  },
+                  "role": {
+                    "type": "string",
+                    "enum": [
+                      "admin",
+                      "owner",
+                      "manager",
+                      "viewer",
+                      "auditor"
+                    ]
+                  },
+                  "timezone": {
+                    "type": "string"
+                  },
+                  "language": {
+                    "type": "string",
+                    "enum": [
+                      "ja",
+                      "en"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Users"
+        ],
+        "operationId": "deleteUser",
+        "summary": "ユーザーを削除（論理削除）",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "削除完了",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    },
+    "schemas": {
+      "ApiError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "details": {}
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "const": false
+          },
+          "data": {
+            "type": "null"
+          },
+          "error": {
+            "$ref": "#/components/schemas/ApiError"
+          }
+        },
+        "required": [
+          "success",
+          "data",
+          "error"
+        ]
+      },
+      "ApiMeta": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+          },
+          "limit": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+          },
+          "total": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "totalPages": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+          }
+        }
+      },
+      "Owner": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "user_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "owner_kind": {
+            "type": "string",
+            "enum": [
+              "individual",
+              "corporation"
+            ]
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "deleted_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "user_id",
+          "name",
+          "owner_kind",
+          "created_at",
+          "updated_at",
+          "deleted_at"
+        ]
+      },
+      "Loan": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "property_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid"
+          },
+          "owner_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid"
+          },
+          "lender_name": {
+            "type": "string"
+          },
+          "branch_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "loan_type": {
+            "type": "string",
+            "enum": [
+              "mortgage",
+              "business",
+              "personal",
+              "other"
+            ]
+          },
+          "principal_amount": {
+            "type": "number"
+          },
+          "current_balance": {
+            "type": "number"
+          },
+          "interest_rate": {
+            "type": "number"
+          },
+          "loan_term_months": {
+            "type": "number"
+          },
+          "monthly_payment": {
+            "type": "number"
+          },
+          "notes": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "deleted_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "lender_name",
+          "loan_type",
+          "principal_amount",
+          "current_balance",
+          "interest_rate",
+          "loan_term_months",
+          "monthly_payment",
+          "created_at",
+          "updated_at",
+          "deleted_at"
+        ]
+      },
+      "Property": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "user_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
+          },
+          "property_type": {
+            "type": "string",
+            "enum": [
+              "apartment",
+              "office",
+              "house",
+              "land",
+              "commercial",
+              "industrial",
+              "mixed_use",
+              "other"
+            ]
+          },
+          "purchase_price": {
+            "type": "number"
+          },
+          "purchase_date": {
+            "type": "string"
+          },
+          "current_valuation": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "deleted_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "user_id",
+          "name",
+          "address",
+          "property_type",
+          "purchase_price",
+          "purchase_date",
+          "current_valuation",
+          "created_at",
+          "updated_at",
+          "deleted_at"
+        ]
+      },
+      "Expense": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "property_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "expense_date": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "management_fee",
+              "repair_cost",
+              "utility",
+              "insurance",
+              "tax",
+              "other"
+            ]
+          },
+          "amount": {
+            "type": "number"
+          },
+          "vendor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "receipt_url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "is_recurring": {
+            "type": "boolean"
+          },
+          "recurring_frequency": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "deleted_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "property_id",
+          "expense_date",
+          "category",
+          "amount",
+          "vendor",
+          "description",
+          "receipt_url",
+          "is_recurring",
+          "recurring_frequency",
+          "created_at",
+          "updated_at",
+          "deleted_at"
+        ]
+      },
+      "RentRoll": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "property_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "room_number": {
+            "type": "string"
+          },
+          "tenant_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "monthly_rent": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "occupancy_status": {
+            "type": "string",
+            "enum": [
+              "occupied",
+              "vacant",
+              "reserved"
+            ]
+          },
+          "lease_start_date": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "lease_end_date": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "security_deposit": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "key_money": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "notes": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "deleted_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "property_id",
+          "room_number",
+          "occupancy_status",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "name": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "admin",
+              "owner",
+              "manager",
+              "viewer",
+              "auditor"
+            ]
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "email",
+          "name",
+          "role",
+          "timezone",
+          "language",
+          "created_at",
+          "updated_at"
+        ]
+      }
+    },
+    "parameters": {
+      "PageParam": {
+        "name": "page",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 1
+        },
+        "description": "ページ番号（1始まり）"
+      },
+      "LimitParam": {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100,
+          "default": 20
+        },
+        "description": "1ページあたり件数"
+      },
+      "SearchParam": {
+        "name": "search",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "検索キーワード（リソースにより適用対象は異なる）"
+      },
+      "SortParam": {
+        "name": "sort",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "ソートキー（リソースに依存）"
+      },
+      "OrderParam": {
+        "name": "order",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "default": "desc"
+        },
+        "description": "ソート順（asc/desc）"
+      }
+    },
+    "responses": {
+      "Unauthorized": {
+        "description": "認証エラー",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "ValidationError": {
+        "description": "バリデーションエラー",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "対象が見つかりません",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "BadRequest": {
+        "description": "不正なリクエスト",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/generated/schema.d.ts
+++ b/packages/generated/schema.d.ts
@@ -228,6 +228,15 @@ export interface components {
             total?: number;
             totalPages?: number;
         };
+        ProblemDetails: {
+            /** Format: uri */
+            type?: string;
+            title: string;
+            status: number;
+            detail?: string;
+            instance?: string;
+            code?: string;
+        };
         Owner: {
             /** Format: uuid */
             id: string;
@@ -335,7 +344,7 @@ export interface components {
                 [name: string]: unknown;
             };
             content: {
-                "application/json": components["schemas"]["ErrorResponse"];
+                "application/problem+json": components["schemas"]["ProblemDetails"];
             };
         };
         /** @description バリデーションエラー */
@@ -344,7 +353,7 @@ export interface components {
                 [name: string]: unknown;
             };
             content: {
-                "application/json": components["schemas"]["ErrorResponse"];
+                "application/problem+json": components["schemas"]["ProblemDetails"];
             };
         };
         /** @description 対象が見つかりません */
@@ -353,7 +362,7 @@ export interface components {
                 [name: string]: unknown;
             };
             content: {
-                "application/json": components["schemas"]["ErrorResponse"];
+                "application/problem+json": components["schemas"]["ProblemDetails"];
             };
         };
         /** @description 不正なリクエスト */
@@ -362,7 +371,16 @@ export interface components {
                 [name: string]: unknown;
             };
             content: {
-                "application/json": components["schemas"]["ErrorResponse"];
+                "application/problem+json": components["schemas"]["ProblemDetails"];
+            };
+        };
+        /** @description サーバ内部エラー */
+        InternalError: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/problem+json": components["schemas"]["ProblemDetails"];
             };
         };
     };


### PR DESCRIPTION
## 概要

RFC 9457 Problem Details を導入し、4xx/5xxのOpenAPIレスポンスを `application/problem+json` に統一しました。実装は段階移行として、エラー時は problem+json を返しつつ現行のエンベロープ（`success:false`/`error:{...}`）を同梱し、フロント/テストの互換を維持しています（成功レスポンスは従来どおり）。

## 変更内容
- OpenAPI: `components.responses` を `application/problem+json` へ統一（Unauthorized/ValidationError/NotFound/BadRequest/InternalError）
- Schema: `ProblemDetails` を追加（`type`/`title`/`status`/`detail`/`instance`, 拡張に `code`）
- 実装: `ApiResponse` のエラー系を problem+json 返却へ変更（互換の envelope を同梱）
- テスト: OpenAPIドキュメントテストに problem+json の検証を追加
- 契約生成: OpenAPI再出力→types生成→client再生成（`packages/generated/`）

## 運用方針（段階移行）
- v1: エラーは problem+json、ボディに互換エンベロープを同梱（既存フロント/APIクライアントはそのまま動作）
- v2: 互換エンベロープの完全撤去を予定（Issue化）

## 確認項目（実行済み）
- `npx turbo run lint / typecheck / test` → Green（28 suites / 156 tests）
- `openapi:emit:node → openapi:types → client:gen` → 生成OK

## 影響範囲
- エラー応答のContent-Typeが `application/problem+json` に変わります（ボディ互換あり）。
- 成功応答は従来どおり（SSOT: Zod→OpenAPI）。

Resolves #<関連Issueがあれば記入>
